### PR TITLE
Add Google sign-in support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Email Automation
 
-This repository provides a basic example of automating email workflows using Python and a minimal front-end interface. Originally it only created Gmail drafts from a CSV file, but it has been extended to optionally send the emails directly via SMTP. A simple React based page allows importing the CSV file, uploading it to the backend and either creating drafts or sending the emails in order.
+This repository provides a basic example of automating email workflows using Python and a minimal front-end interface. Originally it only created Gmail drafts from a CSV file, but it has been extended to optionally send the emails directly via SMTP. A simple React based page allows importing the CSV file, uploading it to the backend and either creating drafts or sending the emails in order. A Google sign‑in button can be used to authorize the application for creating and sending messages through the Gmail API.
+
+To enable Google authentication, define a `GOOGLE_CLIENT_ID` global variable in `public/index.html` with your OAuth client ID. The sign-in button will request access to send email on behalf of the signed in user and the resulting token is passed to the backend API.
 
 ## Deploying to Vercel
 

--- a/api/index.py
+++ b/api/index.py
@@ -25,37 +25,63 @@ def upload():
 def create():
     data = request.get_json() or {}
     csv_path = data.get('csv')
-    imap = data.get('imap')
-    user = data.get('user')
-    password = data.get('password')
-    if not all([csv_path, imap, user, password]):
-        return jsonify({'error': 'missing params'}), 400
-    creator = DraftCreator(imap, user, password)
-    try:
-        count = creator.create_drafts(csv_path)
-        log(f'Created {count} drafts from {csv_path}')
-        return jsonify({'created': count})
-    except Exception as e:
-        log(f'Error: {e}')
-        return jsonify({'error': str(e)}), 500
+    token = data.get('token')
+    if token:
+        if not csv_path:
+            return jsonify({'error': 'missing params'}), 400
+        creator = DraftCreator('', '', '')
+        try:
+            count = creator.create_drafts_api(csv_path, token)
+            log(f'Created {count} drafts from {csv_path} via Gmail API')
+            return jsonify({'created': count})
+        except Exception as e:
+            log(f'Error: {e}')
+            return jsonify({'error': str(e)}), 500
+    else:
+        imap = data.get('imap')
+        user = data.get('user')
+        password = data.get('password')
+        if not all([csv_path, imap, user, password]):
+            return jsonify({'error': 'missing params'}), 400
+        creator = DraftCreator(imap, user, password)
+        try:
+            count = creator.create_drafts(csv_path)
+            log(f'Created {count} drafts from {csv_path}')
+            return jsonify({'created': count})
+        except Exception as e:
+            log(f'Error: {e}')
+            return jsonify({'error': str(e)}), 500
 
 @app.post('/send')
 def send():
     data = request.get_json() or {}
     csv_path = data.get('csv')
-    smtp = data.get('smtp')
-    user = data.get('user')
-    password = data.get('password')
-    if not all([csv_path, smtp, user, password]):
-        return jsonify({'error': 'missing params'}), 400
-    creator = DraftCreator('', user, password)
-    try:
-        count = creator.send_emails(csv_path, smtp)
-        log(f'Sent {count} emails from {csv_path}')
-        return jsonify({'sent': count})
-    except Exception as e:
-        log(f'Error: {e}')
-        return jsonify({'error': str(e)}), 500
+    token = data.get('token')
+    if token:
+        if not csv_path:
+            return jsonify({'error': 'missing params'}), 400
+        creator = DraftCreator('', '', '')
+        try:
+            count = creator.send_emails_api(csv_path, token)
+            log(f'Sent {count} emails from {csv_path} via Gmail API')
+            return jsonify({'sent': count})
+        except Exception as e:
+            log(f'Error: {e}')
+            return jsonify({'error': str(e)}), 500
+    else:
+        smtp = data.get('smtp')
+        user = data.get('user')
+        password = data.get('password')
+        if not all([csv_path, smtp, user, password]):
+            return jsonify({'error': 'missing params'}), 400
+        creator = DraftCreator('', user, password)
+        try:
+            count = creator.send_emails(csv_path, smtp)
+            log(f'Sent {count} emails from {csv_path}')
+            return jsonify({'sent': count})
+        except Exception as e:
+            log(f'Error: {e}')
+            return jsonify({'error': str(e)}), 500
 
 @app.get('/log')
 def get_log():

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,28 @@
 function App() {
   const [csv, setCsv] = React.useState(null);
   const [log, setLog] = React.useState([]);
-  const [form, setForm] = React.useState({imap: '', smtp: '', user: '', password: ''});
+  const [form, setForm] = React.useState({
+    imap: '',
+    smtp: '',
+    user: '',
+    password: '',
+    token: ''
+  });
+
+  const signIn = () => {
+    if (!window.google || !window.google.accounts) return;
+    const client = window.google.accounts.oauth2.initTokenClient({
+      client_id: window.GOOGLE_CLIENT_ID || 'YOUR_GOOGLE_CLIENT_ID',
+      scope:
+        'https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.send',
+      callback: (resp) => {
+        if (resp.access_token) {
+          setForm((f) => ({ ...f, token: resp.access_token }));
+        }
+      },
+    });
+    client.requestAccessToken();
+  };
 
   const fetchLog = async () => {
     const res = await fetch('/api/log');
@@ -46,6 +67,10 @@ function App() {
       <h1>Email Draft Automation</h1>
       <input type="file" accept=".csv" onChange={e => setCsv(e.target.files[0])} />
       <button onClick={upload}>Upload CSV</button>
+      <div>
+        <button onClick={signIn}>Sign in with Google</button>
+        {form.token && <span style={{marginLeft: '8px'}}>Signed in</span>}
+      </div>
       <div>
         <input placeholder="IMAP server" value={form.imap} onChange={e => setForm({...form, imap: e.target.value})} />
         <input placeholder="SMTP server" value={form.smtp} onChange={e => setForm({...form, smtp: e.target.value})} />

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,11 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script>
+    // Replace with your Google OAuth client ID
+    window.GOOGLE_CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';
+  </script>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; }
     .container { max-width: 600px; margin: auto; }


### PR DESCRIPTION
## Summary
- support Gmail OAuth tokens in backend
- add Google sign-in button to frontend
- document OAuth setup in README

## Testing
- `python -m py_compile api/index.py backend/email_draft.py backend/app.py`
- `python api/index.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6880c334be988331b5634fec5c808730